### PR TITLE
Fix annotation discrepancies in GFF3 output from cdna_alignment_orf_to_genome_orf.pl

### DIFF
--- a/util/cdna_alignment_orf_to_genome_orf.pl
+++ b/util/cdna_alignment_orf_to_genome_orf.pl
@@ -315,8 +315,8 @@ sub place_orf_in_cdna_alignment_context {
             $WARNING_COUNT++;
             print STDERR "-Warning [$WARNING_COUNT], orf found on opposite strand of single-exon transcript. Reorienting transcribed direction accordingly to match orf orient on genome (-).\n";
 
+            print STDERR "Model_feat_name: $orf_gene_obj->{Model_feat_name}\n";
             print STDERR "CDS coords: $cds_span_lend, $cds_span_rend\n";
-            
             $cds_genome_lend = &from_cdna_genome_lend($cds_span_lend, \@exon_coords);
             $cds_genome_rend = &from_cdna_genome_lend($cds_span_rend, \@exon_coords);
             
@@ -334,7 +334,9 @@ sub place_orf_in_cdna_alignment_context {
 
             $WARNING_COUNT++;
             print STDERR "-Warning [$WARNING_COUNT], orf found on opposite strand of single-exon transcript. Reorienting transcribed direction accordingly to match orf orient on genome (+).\n";
-                        
+
+            print STDERR "Model_feat_name: $orf_gene_obj->{Model_feat_name}\n";
+            print STDERR "CDS coords: $cds_span_lend, $cds_span_rend\n";            
             $cds_genome_lend = &from_cdna_genome_lend($trans_seq_length - $cds_span_rend +1, \@exon_coords);
             $cds_genome_rend = &from_cdna_genome_lend($trans_seq_length - $cds_span_lend +1, \@exon_coords);
             $transcribed_orient = '+';


### PR DESCRIPTION
`cdna_alignment_orf_to_genome_orf.pl` previously mismatched the Name field for isoforms originating from the same gene, assigning the `transcript ID`, `ORF type`, `length`, and `strand` of the first encountered isoform to all isoforms. This update corrects that behavior by using transcript-specific rather than gene-level info, so each isoform now carries its own `transcript ID`, `ORF type`, `length`, and `strand` in the Name field.

There is also a minor change: `Model_feat_name` and `CDS coords` are now printed explicitly in the warning messages for easier trouble tracking.